### PR TITLE
Fix device comparison type conversion

### DIFF
--- a/device.go
+++ b/device.go
@@ -16,9 +16,9 @@ func getBestDevice() *cl.OpenCLDevice {
 	var maxUnits uint32
 	for _, p := range info.Platforms {
 		for _, d := range p.Devices {
-			if d.Max_compute_units > maxUnits {
+			if uint32(d.Max_compute_units) > maxUnits {
 				best = d
-				maxUnits = d.Max_compute_units
+				maxUnits = uint32(d.Max_compute_units)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- fix type mismatch when comparing Max_compute_units to maxUnits

## Testing
- `go run .` (fails gracefully with no OpenCL device)
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_685268884b38832ab067656f50bcf834