### PR TITLE
Fix 4:3 Mandelbrot bounds

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,8 +90,8 @@ func main() {
 	maxIter := uint32(100)
 	xmin := float32(-2.0)
 	xmax := float32(1.0)
-	ymin := float32(-1.2)
-	ymax := float32(1.2)
+	ymin := float32(-1.125)
+	ymax := float32(1.125)
 
 	bufSize := int(width * height * 8)
 	imgBuf, err := runner.CreateEmptyBuffer(cl.WRITE_ONLY, bufSize)


### PR DESCRIPTION
## Summary
- tweak Mandelbrot Y range to produce a 4:3 aspect image

## Testing
- `go vet ./...` *(fails: `CL/cl.h` not found)*
- `go build ./...` *(fails: `CL/cl.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f45ce12c832aa3a923eab24e160c